### PR TITLE
Add deleteFiles function and update reset script

### DIFF
--- a/src/reset.ts
+++ b/src/reset.ts
@@ -1,19 +1,22 @@
 import { NS } from "@ns";
-import { clearPortData, writeFileList, tryWriteData } from "util/data";
+import { clearPortData, writeFileList, tryWriteData, deleteFiles } from "util/data";
 import { NetworkServer, refreshNetworkScan } from "util/network";
 import { nukeServers, injectMalware } from "util/crack";
+import { log } from "./util/log";
 
 /**
  * Lightweight minimal script to clear data and nuke servers.
  * This enables a control script to be executed on other servers.
  * @param ns - The netscript interface to bitburner functions.
  * @returns A promise that resolves once the reset is complete.
- * @remarks RAM cost: 3.95 GB (base, exec, scp, ls, scan, nuke)
+ * @remarks RAM cost: 4.95 GB (base, exec, rm, scp, ls, scan, nuke)
  */
 export async function main(ns: NS): Promise<void> {
 
+    /* All ports are cleared when you start the game or soft reset
+     * but clearPortData() in case I manually want to reset while testing scripts.
+     */
     clearPortData(ns);    
-    // skip deleteFiles, just overwrite them // deleteFiles(ns, "/data/", "home");
 
     // Scan network to max depth 50, force overwrite of network data
     const networkNodes = refreshNetworkScan(ns, 50, true) as NetworkServer[];
@@ -21,6 +24,16 @@ export async function main(ns: NS): Promise<void> {
     // Nuke all servers at depth 1 or 2 (will silently fail if ports are closed)
     const vulnerableServers = networkNodes.filter(node => node.depth >= 1 && node.depth <= 2);
     nukeServers(ns, vulnerableServers);
+
+    // Delete files on all servers
+    for (const server of networkNodes) {
+        log(ns, `Deleting files on ${server.hostname}`)
+        deleteFiles(ns, "/data/", server.hostname)
+        if (server.hostname != "home") {
+            deleteFiles(ns, "/malware/", server.hostname)
+            deleteFiles(ns, "/util/", server.hostname)
+        }
+    }
 
     // Copy malware to all servers
     writeFileList(ns, "/data/malware.txt", "/malware/", "home");


### PR DESCRIPTION
This pull request adds the `deleteFiles` function to the `util/data` module and updates the `reset` script to use it. The `deleteFiles` function allows for the deletion of files on all servers, while the `reset` script now uses this function to delete files on each server in the network. This ensures that all files are properly cleared during the reset process. Additionally, the `reset` script now logs the deletion of files on each server for better visibility. This PR improves the functionality and reliability of the reset process. Fixes #1234